### PR TITLE
Add onCompletedOptions extension

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -15,7 +15,7 @@ The lack of any kind of introspection prevents the development of a number of se
 
 ## Proposed API
 
-We propose that a limited set of TLS connection stateinformation be presented in a new object as part of the `onCompleted` request callback. Providing this information only on the completion of a request would prevent extensions from attempting to meddle with the browsers internal validation engine and would simply provide a window into the outcome of the validation procedures. In cases where the connection fails to complete, such as when Chrome shows validity warning interstitials, the `onCompleted` event is never actualy fired preventing extensions from attempting to subvert various invalidity states.
+We propose that a limited set of TLS connection stateinformation be presented in a new object as part of the `onCompleted` request callback. Providing this information only on the completion of a request would prevent extensions from attempting to meddle with the browsers internal validation engine and would simply provide a window into the outcome of the validation procedures. In cases where the connection fails to complete, such as when Chrome shows validity warning interstitials, the `onCompleted` event is never actualy fired preventing extensions from attempting to subvert various invalidity states. A extension to the `onCompletedOptions` enum is also proposed in order to prevent unwanted performance regressions for extensions which are not interested in inspecting TLS information.
 
 ### `details` object extension
 
@@ -53,6 +53,10 @@ This new TLS state object should have the key `tlsInfo` and be included in the `
   `tlsVersion: string (optional)`
 
   Again there is no way of extracting this from the chain, useful for determining version deployment and it is hard to determine with crawling without replicating the same protocol version support that the browser has on an ongoing basis. Format should be a basic string containing the specific protocol and the RFC standardized version (i.e. `TLS 1.2` or `SSL 3.0`). Field should not be present if `protocol` contains the value `QUIC`.
+
+### `OnCompletedOptions` extension
+
+Given that adding the `tlsInfo` object can contain relatively large buffers containing the DER encoding of the certificates and there is no upper limit to the number of certificates in a chain this may introduce unwanted performance regressions for certain extensions. In order to prevent this the `OnCompletedOptions` enum should be extended to include a new `tlsInfo` value. The `tlsInfo` object detailed above should only be included in the `details` object passed to the provided callback function if this new value is included in the `opt_extraInfoSpec` passed to the `addListener` method.
 
 ## Open Questions
 


### PR DESCRIPTION
In order to prevent possible performance regressions for extensions that don't care about TLS.